### PR TITLE
Update Auth.swift

### DIFF
--- a/Drift/Models/Auth.swift
+++ b/Drift/Models/Auth.swift
@@ -15,8 +15,10 @@ struct Auth: Mappable {
     var enduser: User?
     
     init?(map: Map) {
+        let stringAccessToken = map["accessToken"] as? String
+        
         //These fields are required, without them we fail to init the object
-        if map["accessToken"] == nil || map["accessToken"] as? String == ""{
+        if stringAccessToken == nil || stringAccessToken?.count == 0 {
             return nil
         }
     }


### PR DESCRIPTION
Hi, sometimes my app crashes trying to access `var accessToken: String!` when token is nil.
It seems to me that `if map["accessToken"] == nil || map["accessToken"] as? String == ""` doesn't handle case when token is not a string and that's the cause of the crash.
So I tried to fix it in my pull request.