### PR TITLE
Filter Automated conversations

### DIFF
--- a/Drift/Managers/ConversationsManager.swift
+++ b/Drift/Managers/ConversationsManager.swift
@@ -14,7 +14,10 @@ class ConversationsManager {
         DriftAPIManager.getEnrichedConversations(userId) { (result) in
             switch result {
             case .success(let conversations):
-                let conversationsToShow = conversations.filter({$0.unreadMessages > 0 && $0.conversation.status != nil})
+                var conversationsToShow = conversations.filter({$0.unreadMessages > 0})
+                if !DriftManager.sharedInstance.automatedMessages {
+                    conversationsToShow = conversationsToShow.filter({ $0.conversation.status != nil })
+                }
                 PresentationManager.sharedInstance.didRecieveNewMessages(conversationsToShow)
             case .failure(let error):
                 LoggerManager.didRecieveError(error)

--- a/Drift/Managers/ConversationsManager.swift
+++ b/Drift/Managers/ConversationsManager.swift
@@ -14,9 +14,13 @@ class ConversationsManager {
         DriftAPIManager.getEnrichedConversations(userId) { (result) in
             switch result {
             case .success(let conversations):
-                var conversationsToShow = conversations.filter({$0.unreadMessages > 0})
-                if !DriftManager.sharedInstance.automatedMessages {
-                    conversationsToShow = conversationsToShow.filter({ $0.conversation.status != nil })
+                let conversationsToShow: [EnrichedConversation]
+                if DriftManager.sharedInstance.shouldShowAutomatedMessages {
+                    //Show conversations with unread > 0
+                    conversationsToShow = conversations.filter({$0.unreadMessages > 0})
+                } else {
+                    //Show unread conversations that we have a status for (Remove automated messages)
+                    conversationsToShow = conversations.filter({ $0.unreadMessages > 0 && $0.conversation.status != nil })
                 }
                 PresentationManager.sharedInstance.didRecieveNewMessages(conversationsToShow)
             case .failure(let error):

--- a/Drift/Managers/ConversationsManager.swift
+++ b/Drift/Managers/ConversationsManager.swift
@@ -14,7 +14,7 @@ class ConversationsManager {
         DriftAPIManager.getEnrichedConversations(userId) { (result) in
             switch result {
             case .success(let conversations):
-                let conversationsToShow = conversations.filter({$0.unreadMessages > 0})
+                let conversationsToShow = conversations.filter({$0.unreadMessages > 0 && $0.conversation.status != nil})
                 PresentationManager.sharedInstance.didRecieveNewMessages(conversationsToShow)
             case .failure(let error):
                 LoggerManager.didRecieveError(error)

--- a/Drift/Managers/DriftAPIManager.swift
+++ b/Drift/Managers/DriftAPIManager.swift
@@ -151,13 +151,7 @@ class DriftAPIManager: Alamofire.SessionManager {
             completion(mapResponse(result))
         }
     }
-    
-    class func getConversations(_ endUserId: Int64, completion: @escaping (_ result: Result<[Conversation]>) -> ()){
-        sharedManager.request(DriftConversationRouter.getConversationsForEndUser(endUserId: endUserId)).responseJSON(completionHandler: { (result) -> Void in
-            completion(mapResponse(result))
-        })
-    }
-    
+        
     class func getMessages(_ conversationId: Int, authToken: String, completion: @escaping (_ result: Result<[Message]>) -> ()){
         sharedManager.request(DriftConversationRouter.getMessagesForConversation(conversationId: conversationId)).responseJSON(completionHandler: { (result) -> Void in
             completion(mapResponse(result))

--- a/Drift/Managers/DriftAPIURLRouter.swift
+++ b/Drift/Managers/DriftAPIURLRouter.swift
@@ -123,7 +123,6 @@ enum DriftConversationRouter: URLRequestConvertible {
     case getCampaignsForEndUser(endUserId: Int64)
     
     case getEnrichedConversationsForEndUser(endUserId: Int64)
-    case getConversationsForEndUser(endUserId: Int64)
     case getMessagesForConversation(conversationId: Int)
     case postMessageToConversation(conversationId: Int, data: [String: Any])
     case createConversation(data: [String: Any])
@@ -136,8 +135,6 @@ enum DriftConversationRouter: URLRequestConvertible {
             return (.get, "conversations/end_users/\(endUserId)/campaigns", nil, URLEncoding.default)
         case .getEnrichedConversationsForEndUser(let endUserId):
             return (.get, "conversations/end_users/\(endUserId)/extra", nil, URLEncoding.default)
-        case .getConversationsForEndUser(let endUserId):
-            return (.get, "conversations/end_users/\(endUserId)", nil, URLEncoding.default)
         case .getMessagesForConversation(let conversationId):
             return (.get, "conversations/\(conversationId)/messages", nil, URLEncoding.default)
         case .postMessageToConversation(let conversationId, let data):

--- a/Drift/Managers/DriftManager.swift
+++ b/Drift/Managers/DriftManager.swift
@@ -13,6 +13,7 @@ class DriftManager: NSObject {
     
     static var sharedInstance: DriftManager = DriftManager()
     var debug: Bool = false
+    var automatedMessages: Bool = true
     var showArchivedCampaigns = true
     var directoryURL: URL?
     ///Used to store register data while we wait for embed to finish in case where register and embed is called together
@@ -67,6 +68,10 @@ class DriftManager: NSObject {
     
     class func debugMode(_ debug:Bool){
         sharedInstance.debug = debug
+    }
+    
+    class func showAutomatedMessages(_ show: Bool) {
+        sharedInstance.automatedMessages = show
     }
     
     /**

--- a/Drift/Managers/DriftManager.swift
+++ b/Drift/Managers/DriftManager.swift
@@ -13,7 +13,7 @@ class DriftManager: NSObject {
     
     static var sharedInstance: DriftManager = DriftManager()
     var debug: Bool = false
-    var automatedMessages: Bool = true
+    var shouldShowAutomatedMessages: Bool = true
     var showArchivedCampaigns = true
     var directoryURL: URL?
     ///Used to store register data while we wait for embed to finish in case where register and embed is called together
@@ -71,7 +71,7 @@ class DriftManager: NSObject {
     }
     
     class func showAutomatedMessages(_ show: Bool) {
-        sharedInstance.automatedMessages = show
+        sharedInstance.shouldShowAutomatedMessages = show
     }
     
     /**

--- a/Drift/Models/Conversation.swift
+++ b/Drift/Models/Conversation.swift
@@ -23,7 +23,7 @@ class Conversation: Mappable, Equatable{
     var displayId: Int!
     var endUserId: Int64!
     var assigneeId: Int?
-    var status: ConversationStatus!
+    var status: ConversationStatus?
     var subject: String?
     var preview: String?
     var updatedAt = Date()
@@ -44,6 +44,7 @@ class Conversation: Mappable, Equatable{
         subject     <- map["subject"]
         preview     <- map["preview"]
         updatedAt   <- (map["updatedAt"], DriftDateTransformer())
+        status      <- (map["status"], EnumTransform<ConversationStatus>())
         uuid        <- map["uuid"]
         orgId       <- map["orgId"]
         type        <- map["type"]

--- a/Drift/Public/Drift.swift
+++ b/Drift/Public/Drift.swift
@@ -80,4 +80,16 @@ open class Drift: NSObject {
     @objc open class func showCreateConversation() {
         DriftManager.showCreateConversation()
     }
+    
+    /**
+     
+     This allows you to filter out automated messages and only show messages the end user has interacted with
+     This will stop automated messages on the web showing up in the app.
+     
+     - parameter debug: A Bool indicating if automated conversations should be shown - Default true
+     
+     */
+    @objc open class func showAutomatedMessages(_ show: Bool) {
+        DriftManager.showAutomatedMessages(show)
+    }
 }

--- a/Drift/UI/Conversation List View/ConversationListViewController.swift
+++ b/Drift/UI/Conversation List View/ConversationListViewController.swift
@@ -119,8 +119,8 @@ class ConversationListViewController: UIViewController {
                 self.refreshControl.endRefreshing()
                 SVProgressHUD.dismiss()
                 switch result{
-                case .success(let enrichedConversations):
-                    self.enrichedConversations = enrichedConversations
+                case .success(let enrichedConversationsResult):
+                    self.enrichedConversations = enrichedConversationsResult.filter({ $0.conversation.status != nil })
                     self.tableView.reloadData()
                     if self.enrichedConversations.count == 0{
                         self.emptyStateView.isHidden = false
@@ -162,7 +162,7 @@ extension ConversationListViewController: UITableViewDelegate, UITableViewDataSo
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ConversationListTableViewCell") as! ConversationListTableViewCell
 
-        let enrichedConversation = enrichedConversations[(indexPath as NSIndexPath).row]
+        let enrichedConversation = enrichedConversations[indexPath.row]
         if let conversation = enrichedConversation.conversation {
             if enrichedConversation.unreadMessages > 0 {
                 cell.unreadCountLabel.isHidden = false
@@ -210,7 +210,7 @@ extension ConversationListViewController: UITableViewDelegate, UITableViewDataSo
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let enrichedConversation = enrichedConversations[(indexPath as NSIndexPath).row]
+        let enrichedConversation = enrichedConversations[indexPath.row]
         let conversationViewController = ConversationViewController(conversationType: .continueConversation(conversationId: enrichedConversation.conversation.id))
         navigationController?.show(conversationViewController, sender: self)
     }

--- a/Drift/UI/Conversation List View/ConversationListViewController.swift
+++ b/Drift/UI/Conversation List View/ConversationListViewController.swift
@@ -121,9 +121,11 @@ class ConversationListViewController: UIViewController {
                 switch result{
                 case .success(let enrichedConversationsResult):
                     
-                    if DriftManager.sharedInstance.automatedMessages {
+                    if DriftManager.sharedInstance.shouldShowAutomatedMessages {
+                        //Show all conversations
                        self.enrichedConversations = enrichedConversationsResult
                     } else {
+                        //Filter out conversations we dont have a status for (Automated is BulkSent)
                         self.enrichedConversations = enrichedConversationsResult.filter({ $0.conversation.status != nil })
                     }
                     self.tableView.reloadData()

--- a/Drift/UI/Conversation List View/ConversationListViewController.swift
+++ b/Drift/UI/Conversation List View/ConversationListViewController.swift
@@ -120,7 +120,12 @@ class ConversationListViewController: UIViewController {
                 SVProgressHUD.dismiss()
                 switch result{
                 case .success(let enrichedConversationsResult):
-                    self.enrichedConversations = enrichedConversationsResult.filter({ $0.conversation.status != nil })
+                    
+                    if DriftManager.sharedInstance.automatedMessages {
+                       self.enrichedConversations = enrichedConversationsResult
+                    } else {
+                        self.enrichedConversations = enrichedConversationsResult.filter({ $0.conversation.status != nil })
+                    }
                     self.tableView.reloadData()
                     if self.enrichedConversations.count == 0{
                         self.emptyStateView.isHidden = false

--- a/Example/SDKExample/Podfile.lock
+++ b/Example/SDKExample/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Alamofire (4.7.3)
-  - AlamofireImage (3.4.1):
-    - Alamofire (~> 4.7)
-  - Drift (2.2.7):
+  - Alamofire (4.8.1)
+  - AlamofireImage (3.5.0):
+    - Alamofire (~> 4.8)
+  - Drift (2.2.8):
     - AlamofireImage (~> 3.0)
     - ObjectMapper (~> 3.0)
     - Starscream
     - SVProgressHUD (~> 2.0)
-  - ObjectMapper (3.3.0)
-  - Starscream (3.0.5)
+  - ObjectMapper (3.4.2)
+  - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
 
 DEPENDENCIES:
@@ -27,11 +27,11 @@ EXTERNAL SOURCES:
     :path: "../../Drift.podspec"
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  AlamofireImage: 78d67ccbb763d87ba44b21583d2153500a195630
-  Drift: 46979e76b9d8c8015b17ad0d782c7df7f9731506
-  ObjectMapper: b612bf8c8e99c4dc0bb6013a51f7c27966ed5da9
-  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
+  Alamofire: 16ce2c353fb72865124ddae8a57c5942388f4f11
+  AlamofireImage: 1aea346f4dda2f6c67622fa5a89fcbb80d79cc16
+  Drift: 74ab4a7571c47fad79c50febc166bd95c3eb2d6e
+  ObjectMapper: 0d4402610f4e468903ae64629eec4784531e5c51
+  Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
 
 PODFILE CHECKSUM: 32c3227aad917f1ee3b890bb8103e9fbb3085801

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Alamofire (4.7.3)
-  - AlamofireImage (3.3.1):
-    - Alamofire (~> 4.5)
-  - ObjectMapper (3.3.0)
-  - Starscream (3.0.5)
+  - Alamofire (4.8.1)
+  - AlamofireImage (3.5.0):
+    - Alamofire (~> 4.8)
+  - ObjectMapper (3.4.2)
+  - Starscream (3.0.6)
   - SVProgressHUD (1.1.3)
 
 DEPENDENCIES:
@@ -21,10 +21,10 @@ SPEC REPOS:
     - SVProgressHUD
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  AlamofireImage: 3b35b586853abaf94ca1250f4e94cff3c21a4c0d
-  ObjectMapper: b612bf8c8e99c4dc0bb6013a51f7c27966ed5da9
-  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
+  Alamofire: 16ce2c353fb72865124ddae8a57c5942388f4f11
+  AlamofireImage: 1aea346f4dda2f6c67622fa5a89fcbb80d79cc16
+  ObjectMapper: 0d4402610f4e468903ae64629eec4784531e5c51
+  Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
 
 PODFILE CHECKSUM: 1dc6dd5441363b0a3b51593861df9c17e89bca3c


### PR DESCRIPTION
This PR adds the ability to filter conversations that are automated like conversations from Drift bot playbooks. This is a configurable settings for the user and the default values do not change the current configuration which is to show all conversations.