### PR TITLE
fix: socket auth decoding: decode org id as string

### DIFF
--- a/Drift/Managers/SocketManager.swift
+++ b/Drift/Managers/SocketManager.swift
@@ -34,7 +34,7 @@ class SocketManager {
             socket.disconnect()
         }
         
-        socket = Socket(url: getSocketEndpoint(orgId: socketAuth.orgId), params: ["session_token": socketAuth.sessionToken], callbackQueue: socketResponseQueue)
+        socket = Socket(url: getSocketEndpoint(orgId: Int(socketAuth.orgId) ?? -1), params: ["session_token": socketAuth.sessionToken], callbackQueue: socketResponseQueue)
         socket?.enableLogging = DriftManager.sharedInstance.debug
         socket?.onConnect =  {
             self.didConnect()

--- a/Drift/Models/SocketAuth.swift
+++ b/Drift/Models/SocketAuth.swift
@@ -9,7 +9,7 @@
 struct SocketAuth {
     let sessionToken: String
     let userId: String
-    let orgId: Int
+    let orgId: String
 }
 
 class SocketAuthDTO: Codable, DTO {
@@ -18,13 +18,13 @@ class SocketAuthDTO: Codable, DTO {
     
     var sessionToken: String?
     var userId: String?
-    var orgId: Int?
+    var orgId: String?
     
     
     func mapToObject() -> SocketAuth? {
         return SocketAuth(sessionToken: sessionToken ?? "",
                           userId: userId ?? "",
-                          orgId: orgId ?? -1)
+                          orgId: orgId ?? "")
     }
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
Hi! We are using your SDK for about two years and it is great!
I catched an error when object received from backed is not decoded: SocketAuth's 'org_id' field is Int, but backend returns is as String.
As a workaround I changed this field to String and now it works. Can you have a look?